### PR TITLE
Rails version compatibility appraisal

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,12 @@
+appraise "rails-2" do
+  gem "iconv"
+  gem "rails", "2.3.18"
+end
+
+appraise "rails-3" do
+  gem "rails", "3.2.14"
+end
+
+appraise "rails-4" do
+  gem "rails", "4.1.8"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ begin
     s.rubyforge_project = %q{quirkey}
     s.add_runtime_dependency(%q<activesupport>, [">= 2.2.0"])
     s.add_runtime_dependency(%q<chronic>, ["~>0.10", ">= 0.10.2"])
+    s.add_development_dependency(%q<appraisal>, ["~>1.0", ">= 1.0.2"])
     s.add_development_dependency(%q<rake>, ["~>10.4", ">= 10.4.2"])
     s.add_development_dependency(%q<minitest>, ["~> 5.5", ">= 5.5.0"])
     s.add_development_dependency(%q<shoulda-context>, ["~> 1.2", ">= 1.2.1"])

--- a/restful_query.gemspec
+++ b/restful_query.gemspec
@@ -49,11 +49,13 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>, [">= 2.2.0"])
       s.add_runtime_dependency(%q<chronic>, ["~>0.10", ">= 0.10.2"])
+      s.add_development_dependency(%q<appraisal>, ["~>1.0", ">= 1.0.2"])
       s.add_development_dependency(%q<rake>, ["~>10.4", ">= 10.4.2"])
       s.add_development_dependency(%q<minitest>, ["~> 5.5", ">= 5.5.0"])
       s.add_development_dependency(%q<shoulda-context>, ["~> 1.2", ">= 1.2.1"])
     else
       s.add_dependency(%q<activesupport>, [">= 2.2.0"])
+      s.add_dependency(%q<appraisal>, ["~>1.0", ">= 1.0.2"])
       s.add_dependency(%q<chronic>, ["~>0.10", ">= 0.10.2"])
       s.add_dependency(%q<minitest>, ["~> 5.5", ">= 5.5.0"])
       s.add_dependency(%q<rake>, ["~>10.4", ">= 10.4.2"])
@@ -61,6 +63,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<activesupport>, [">= 2.2.0"])
+    s.add_dependency(%q<appraisal>, ["~>1.0", ">= 1.0.2"])
     s.add_dependency(%q<chronic>, ["~>0.10", ">= 0.10.2"])
     s.add_dependency(%q<minitest>, ["~> 5.5", ">= 5.5.0"])
     s.add_dependency(%q<rake>, ["~>10.4", ">= 10.4.2"])


### PR DESCRIPTION
Includes: https://github.com/quirkey/restful_query/pull/6

Adds the [appraisal](https://rubygems.org/gems/appraisal) gem as a development dependency and uses it to appraise *restful_query*'s compatibility with Rails 2, 3 and 4.

Tests are passing with all three

To run appraisal:

```
bundle install
bundle exec appraisal install
bundle exec appraisal rails-2 rake test
bundle exec appraisal rails-3 rake test
bundle exec appraisal rails-4 rake test
```