### PR TITLE
Bump to 0.4.0, gem tweaks

### DIFF
--- a/lib/restful_query.rb
+++ b/lib/restful_query.rb
@@ -5,7 +5,7 @@ require "active_support"
 require "chronic"
 
 module RestfulQuery
-  VERSION = "0.3.6"
+  VERSION = "0.4.0"
 
   class Error < RuntimeError; end
 end

--- a/restful_query.gemspec
+++ b/restful_query.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
     "README.rdoc"
   ]
   s.files = [
+    "Appraisals",
     "Gemfile",
     "History.txt",
     "LICENSE",


### PR DESCRIPTION
Bumps the version to 0.4.0-- used the minor version to be cautious with the Gemfile/dependency changes even though the code itself should be compatible with 0.3.6

Adds the Appraisals file to the gem too